### PR TITLE
オプションの内容が分からない

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -19,7 +19,8 @@ append :linked_dirs, "log", "public", "tmp"
 
 # You can configure the Airbrussh format using :format_options.
 # These are the defaults.
-# set :format_options, command_output: true, log_file: "log/capistrano.log", color: :auto, truncate: :auto
+# デプロイコマンドのすべてを表示
+set :format_options, truncate: false
 
 # Default value for :pty is false
 # set :pty, true


### PR DESCRIPTION
rubocopで100文字以上でエラーが表示された。
自動生成されたもので、内容を把握できないためbranchを作成しました。

調べるとCapistranoのコマンドでdeployする際の記述とのこと

デプロイ時にログをすべて表示する方法がのっていたので、それを追記しました。